### PR TITLE
Fix citation formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,38 +13,28 @@ A crowd-sourcing server prototype to facilitate experimentation and push the fro
 
 Please use this citation when referring to this archive:
 
-B. Bošković, F. Brglez and J. Brest, **A GitHub Archive for Solvers and Solutions of the labs problem**, 2016
+`B. Bošković, F. Brglez and J. Brest, **A GitHub Archive for Solvers and Solutions of the labs problem**, 2016`
 
-
+```
 @misc{OPUS2-git_labs-Boskovic,
-
 	Author = {B. Bo\v{s}kovi\'{c} and F. Brglez and J. Brest},
-
 	Howpublished = {{For updates, see \url{https://github.com/borkob/git_labs}. }},
-
 	Month = {January},
-
 	Title = {{A GitHub Archive for Solvers and Solutions of the {\tt labs} problem}},
-
 	Year = {2016}
-
 }
+```
 
 The organization of this archive, including the open-source state-of-the-art solvers and summaries of experimental results,
 is based on this paper:
 
+`B. Bošković, F. Brglez and J. Brest, **Low-Autocorrelation Binary Sequences: On Improved Merit Factors and Runtime Predictions to Achieve Them**`, http://arxiv.org/abs/1406.5301, under review
 
-B. Bošković, F. Brglez and J. Brest, **Low-Autocorrelation Binary Sequences: On Improved Merit Factors and Runtime Predictions to Achieve Them**, http://arxiv.org/abs/1406.5301, under review
-
+```
 @article{OPUS2-labs-2016-arxiv-Boskovic,
-
 	Author = {B. Bo\v{s}kovi\'{c} and F. Brglez and J. Brest},
-
 	Journal = {http://arxiv.org/abs/1406.5301, also under journal review}},
-
 	Title = {{Low-Autocorrelation Binary Sequences: On Improved Merit Factors and Runtime Predictions to Achieve Them}},
-
 	Year = {2016}
-
 }
-
+```


### PR DESCRIPTION
Wrapping the citations in code tags so GitHub displays them properly, and they're easier to copy.